### PR TITLE
Add internationalization for MHTC Chronicles page

### DIFF
--- a/mhtc-web/app/[locale]/corporate-profile/page.tsx
+++ b/mhtc-web/app/[locale]/corporate-profile/page.tsx
@@ -1,5 +1,4 @@
-"use client";
-
+import { Metadata } from "next";
 import Image from "next/image";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
@@ -12,8 +11,25 @@ import {
   BookOpen,
 } from "lucide-react";
 import Link from "next/link";
-import { useTranslation } from "@/hooks/useTranslation";
+import { getServerTranslations, isRTL } from "@/utils/translations";
+import { Locale } from "@/types/i18n";
 import { CorporateProfileTranslations } from "@/types/translations";
+
+export async function generateMetadata({
+  params: { locale },
+}: {
+  params: { locale: Locale };
+}): Promise<Metadata> {
+  const translations = getServerTranslations<CorporateProfileTranslations>(
+    locale,
+    "corporate-profile"
+  );
+
+  return {
+    title: `${translations.hero.title} | Malaysia Healthcare Travel Council`,
+    description: translations.hero.subtitle,
+  };
+}
 
 const iconMap = {
   qualityAssurance: Award,
@@ -24,9 +40,16 @@ const iconMap = {
   capacityBuilding: BookOpen,
 };
 
-export default function CorporateProfile() {
-  const { t, isRTL } =
-    useTranslation<CorporateProfileTranslations>("corporate-profile");
+export default function CorporateProfile({
+  params: { locale },
+}: {
+  params: { locale: Locale };
+}) {
+  const translations = getServerTranslations<CorporateProfileTranslations>(
+    locale,
+    "corporate-profile"
+  );
+  const rtl = isRTL(locale);
 
   const focusAreaKeys = [
     "qualityAssurance",
@@ -38,55 +61,74 @@ export default function CorporateProfile() {
   ];
 
   return (
-    <div className="max-w-7xl mx-auto bg-white min-h-screen">
-      <div className={`container mx-auto px-4 py-16 ${isRTL ? "rtl" : ""}`}>
-        {/* Hero Section */}
-        <div className="max-w-3xl mx-auto text-center mb-16">
-          <h1 className="text-4xl font-bold text-gray-900 mb-6">
-            {t.hero.title}
-          </h1>
-          <p className="text-lg text-gray-600">{t.hero.subtitle}</p>
-        </div>
+    <div
+      className={`max-w-7xl mx-auto bg-white min-h-screen ${
+        rtl ? "rtl" : "ltr"
+      }`}
+    >
+      <div className="container mx-auto px-4 py-16 mt-16">
+        <h1 className="text-4xl font-bold text-primary mb-8">
+          {translations.pageTitle}
+        </h1>
+        <p
+          className="text-lg sm:text-xl text-gray-600 mb-8 sm:mb-12 max-w-3xl"
+          tabIndex={0}
+        >
+          {translations.hero.subtitle}
+        </p>
 
         {/* Mission & Vision Section */}
-        <div className="grid grid-cols-1 lg:grid-cols-2 gap-12 mb-16">
-          <div className="space-y-8">
-            <div>
-              <h2 className="text-2xl font-semibold text-primary mb-4">
-                {t.mission.title}
-              </h2>
-              <Card className="border-none shadow-lg">
-                <CardContent className="p-6">
-                  <p className="text-gray-600">{t.mission.content}</p>
-                </CardContent>
-              </Card>
+        <section className="mb-16" aria-labelledby="mission-vision-title">
+          <h2 id="mission-vision-title" className="sr-only">
+            {translations.mission.title} & {translations.vision.title}
+          </h2>
+          <div className="grid grid-cols-1 lg:grid-cols-2 gap-12">
+            <div className="space-y-8">
+              <div>
+                <h2 className="text-2xl font-semibold text-primary mb-4">
+                  {translations.mission.title}
+                </h2>
+                <Card className="border-none shadow-lg">
+                  <CardContent className="p-6">
+                    <p className="text-gray-600">
+                      {translations.mission.content}
+                    </p>
+                  </CardContent>
+                </Card>
+              </div>
+              <div>
+                <h2 className="text-2xl font-semibold text-primary mb-4">
+                  {translations.vision.title}
+                </h2>
+                <Card className="border-none shadow-lg">
+                  <CardContent className="p-6">
+                    <p className="text-gray-600">
+                      {translations.vision.content}
+                    </p>
+                  </CardContent>
+                </Card>
+              </div>
             </div>
-            <div>
-              <h2 className="text-2xl font-semibold text-primary mb-4">
-                {t.vision.title}
-              </h2>
-              <Card className="border-none shadow-lg">
-                <CardContent className="p-6">
-                  <p className="text-gray-600">{t.vision.content}</p>
-                </CardContent>
-              </Card>
+            <div className="relative h-[500px] rounded-lg overflow-hidden shadow-xl">
+              <Image
+                src="/images/corporate-image.png"
+                alt="MHTC Team"
+                fill
+                className="object-cover"
+                priority
+              />
             </div>
           </div>
-          <div className="relative h-[500px] rounded-lg overflow-hidden shadow-xl">
-            <Image
-              src="/images/corporate-image.png"
-              alt="MHTC Team"
-              fill
-              className="object-cover"
-              priority
-            />
-          </div>
-        </div>
+        </section>
 
         {/* Focus Areas Section */}
-        <section className="mb-16">
-          <h2 className="text-2xl font-semibold text-primary mb-8 text-center">
-            {t.focusAreas.title}
+        <section className="mb-16" aria-labelledby="focus-areas-title">
+          <h2
+            id="focus-areas-title"
+            className="text-2xl font-semibold text-primary mb-8 text-center"
+            tabIndex={0}
+          >
+            {translations.focusAreas.title}
           </h2>
           <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
             {focusAreaKeys.map((key) => {
@@ -98,12 +140,15 @@ export default function CorporateProfile() {
                 >
                   <CardHeader className="space-y-1">
                     <div className="p-2 rounded-lg bg-primary/10 w-fit">
-                      <Icon className="w-5 h-5 text-primary" />
+                      <Icon
+                        className="w-5 h-5 text-primary"
+                        aria-hidden="true"
+                      />
                     </div>
                     <CardTitle className="text-xl">
                       {
-                        t.focusAreas.areas[
-                          key as keyof typeof t.focusAreas.areas
+                        translations.focusAreas.areas[
+                          key as keyof typeof translations.focusAreas.areas
                         ].title
                       }
                     </CardTitle>
@@ -111,8 +156,8 @@ export default function CorporateProfile() {
                   <CardContent>
                     <p className="text-gray-600">
                       {
-                        t.focusAreas.areas[
-                          key as keyof typeof t.focusAreas.areas
+                        translations.focusAreas.areas[
+                          key as keyof typeof translations.focusAreas.areas
                         ].description
                       }
                     </p>
@@ -124,9 +169,13 @@ export default function CorporateProfile() {
         </section>
 
         {/* Achievements Section */}
-        <section className="mb-16">
-          <h2 className="text-2xl font-semibold text-primary mb-8 text-center">
-            {t.achievements.title}
+        <section className="mb-16" aria-labelledby="achievements-title">
+          <h2
+            id="achievements-title"
+            className="text-2xl font-semibold text-primary mb-8 text-center"
+            tabIndex={0}
+          >
+            {translations.achievements.title}
           </h2>
           <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6">
             {(["facilities", "patients", "awards", "years"] as const).map(
@@ -137,10 +186,10 @@ export default function CorporateProfile() {
                 >
                   <CardContent className="pt-6">
                     <p className="text-4xl font-bold text-primary mb-2">
-                      {t.achievements.stats[statKey].number}
+                      {translations.achievements.stats[statKey].number}
                     </p>
                     <p className="text-gray-600">
-                      {t.achievements.stats[statKey].label}
+                      {translations.achievements.stats[statKey].label}
                     </p>
                   </CardContent>
                 </Card>
@@ -150,24 +199,32 @@ export default function CorporateProfile() {
         </section>
 
         {/* CTA Section */}
-        <div className="text-center">
+        <section aria-labelledby="cta-title">
           <Card className="bg-primary text-white border-none">
             <CardContent className="p-8">
-              <h2 className="text-2xl font-bold mb-4">{t.cta.title}</h2>
-              <p className="text-white/90 mb-6">{t.cta.description}</p>
+              <h2
+                id="cta-title"
+                className="text-2xl font-bold mb-4"
+                tabIndex={0}
+              >
+                {translations.cta.title}
+              </h2>
+              <p className="text-white/90 mb-6">
+                {translations.cta.description}
+              </p>
               <div className="flex flex-col sm:flex-row gap-4 justify-center">
                 <Link href="/contact">
                   <Button
                     variant="secondary"
                     className="bg-white text-primary hover:bg-white/90"
                   >
-                    {t.cta.button}
+                    {translations.cta.button}
                   </Button>
                 </Link>
               </div>
             </CardContent>
           </Card>
-        </div>
+        </section>
       </div>
     </div>
   );

--- a/mhtc-web/app/[locale]/mhtc-chronicles/page.tsx
+++ b/mhtc-web/app/[locale]/mhtc-chronicles/page.tsx
@@ -9,12 +9,25 @@ import {
   CardHeader,
   CardTitle,
 } from "@/components/ui/card";
+import { getServerTranslations, isRTL } from "@/utils/translations";
+import { Locale } from "@/types/i18n";
+import { MHTCChroniclesTranslations } from "@/types/translations";
 
-export const metadata: Metadata = {
-  title: "News & Articles | Malaysia Healthcare Travel Council",
-  description:
-    "Stay updated with the latest news, articles, and insights from Malaysia Healthcare Travel Council.",
-};
+export async function generateMetadata({
+  params: { locale },
+}: {
+  params: { locale: Locale };
+}): Promise<Metadata> {
+  const translations = getServerTranslations<MHTCChroniclesTranslations>(
+    locale,
+    "mhtc-chronicles"
+  );
+
+  return {
+    title: `${translations.pageTitle} | Malaysia Healthcare Travel Council`,
+    description: translations.pageDescription,
+  };
+}
 
 const newsArticles = [
   {
@@ -46,12 +59,34 @@ const newsArticles = [
   },
 ];
 
-export default function MHTCChronicles() {
+export default function MHTCChronicles({
+  params: { locale },
+}: {
+  params: { locale: Locale };
+}) {
+  const translations = getServerTranslations<MHTCChroniclesTranslations>(
+    locale,
+    "mhtc-chronicles"
+  );
+  const rtl = isRTL(locale);
+
+  const categoryItems = [
+    translations.categories.items.healthcareInnovations,
+    translations.categories.items.patientStories,
+    translations.categories.items.industryUpdates,
+    translations.categories.items.events,
+    translations.categories.items.travelTips,
+  ];
+
   return (
-    <div className="max-w-7xl mx-auto bg-white min-h-screen">
+    <div
+      className={`max-w-7xl mx-auto bg-white min-h-screen ${
+        rtl ? "rtl" : "ltr"
+      }`}
+    >
       <div className="container mx-auto px-4 py-16 mt-16">
         <h1 className="text-4xl font-bold text-primary mb-8">
-          MHTC Chronicles
+          {translations.pageTitle}
         </h1>
 
         <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-8">
@@ -73,7 +108,9 @@ export default function MHTCChronicles() {
               </CardContent>
               <CardFooter>
                 <Button variant="outline" asChild>
-                  <Link href={`/news/${article.id}`}>Read More</Link>
+                  <Link href={`/news/${article.id}`}>
+                    {translations.articles.readMore}
+                  </Link>
                 </Button>
               </CardFooter>
             </Card>
@@ -81,15 +118,11 @@ export default function MHTCChronicles() {
         </div>
 
         <div className="mt-12">
-          <h2 className="text-2xl font-semibold mb-6">Categories</h2>
+          <h2 className="text-2xl font-semibold mb-6">
+            {translations.categories.title}
+          </h2>
           <div className="flex flex-wrap gap-4">
-            {[
-              "Healthcare Innovations",
-              "Patient Stories",
-              "Industry Updates",
-              "Events",
-              "Travel Tips",
-            ].map((category) => (
+            {categoryItems.map((category) => (
               <Button key={category} variant="outline">
                 {category}
               </Button>
@@ -99,21 +132,18 @@ export default function MHTCChronicles() {
 
         <div className="mt-12">
           <h2 className="text-2xl font-semibold mb-6">
-            Subscribe to Our Newsletter
+            {translations.newsletter.title}
           </h2>
           <Card>
             <CardContent className="pt-6">
-              <p className="mb-4">
-                Stay updated with the latest news and insights from Malaysia
-                Healthcare Travel Council.
-              </p>
+              <p className="mb-4">{translations.newsletter.description}</p>
               <div className="flex gap-4">
                 <input
                   type="email"
-                  placeholder="Enter your email"
+                  placeholder={translations.newsletter.emailPlaceholder}
                   className="flex-grow px-4 py-2 border rounded-md"
                 />
-                <Button>Subscribe</Button>
+                <Button>{translations.newsletter.subscribeButton}</Button>
               </div>
             </CardContent>
           </Card>

--- a/mhtc-web/locales/ar/mhtc-chronicles.json
+++ b/mhtc-web/locales/ar/mhtc-chronicles.json
@@ -1,0 +1,23 @@
+{
+    "pageTitle": "أخبار ومقالات MHTC",
+    "pageDescription": "ابق على اطلاع بأحدث الأخبار والمقالات والرؤى من مجلس السياحة الصحية الماليزي.",
+    "categories": {
+        "title": "الفئات",
+        "items": {
+            "healthcareInnovations": "ابتكارات الرعاية الصحية",
+            "patientStories": "قصص المرضى",
+            "industryUpdates": "تحديثات الصناعة",
+            "events": "الفعاليات",
+            "travelTips": "نصائح السفر"
+        }
+    },
+    "newsletter": {
+        "title": "اشترك في نشرتنا الإخبارية",
+        "description": "ابق على اطلاع بأحدث الأخبار والرؤى من مجلس السياحة الصحية الماليزي.",
+        "emailPlaceholder": "أدخل بريدك الإلكتروني",
+        "subscribeButton": "اشترك"
+    },
+    "articles": {
+        "readMore": "قراءة المزيد"
+    }
+}

--- a/mhtc-web/locales/en/mhtc-chronicles.json
+++ b/mhtc-web/locales/en/mhtc-chronicles.json
@@ -1,0 +1,23 @@
+{
+    "pageTitle": "MHTC Chronicles",
+    "pageDescription": "Stay updated with the latest news, articles, and insights from Malaysia Healthcare Travel Council.",
+    "categories": {
+        "title": "Categories",
+        "items": {
+            "healthcareInnovations": "Healthcare Innovations",
+            "patientStories": "Patient Stories",
+            "industryUpdates": "Industry Updates",
+            "events": "Events",
+            "travelTips": "Travel Tips"
+        }
+    },
+    "newsletter": {
+        "title": "Subscribe to Our Newsletter",
+        "description": "Stay updated with the latest news and insights from Malaysia Healthcare Travel Council.",
+        "emailPlaceholder": "Enter your email",
+        "subscribeButton": "Subscribe"
+    },
+    "articles": {
+        "readMore": "Read More"
+    }
+}

--- a/mhtc-web/locales/id/mhtc-chronicles.json
+++ b/mhtc-web/locales/id/mhtc-chronicles.json
@@ -1,0 +1,23 @@
+{
+    "pageTitle": "Kronik MHTC",
+    "pageDescription": "Dapatkan berita, artikel, dan wawasan terbaru dari Dewan Perjalanan Kesehatan Malaysia.",
+    "categories": {
+        "title": "Kategori",
+        "items": {
+            "healthcareInnovations": "Inovasi Kesehatan",
+            "patientStories": "Kisah Pasien",
+            "industryUpdates": "Pembaruan Industri",
+            "events": "Acara",
+            "travelTips": "Tips Perjalanan"
+        }
+    },
+    "newsletter": {
+        "title": "Berlangganan Buletin Kami",
+        "description": "Tetap terkini dengan berita dan wawasan terbaru dari Dewan Perjalanan Kesehatan Malaysia.",
+        "emailPlaceholder": "Masukkan email Anda",
+        "subscribeButton": "Berlangganan"
+    },
+    "articles": {
+        "readMore": "Baca Selengkapnya"
+    }
+}

--- a/mhtc-web/locales/ms/mhtc-chronicles.json
+++ b/mhtc-web/locales/ms/mhtc-chronicles.json
@@ -1,0 +1,23 @@
+{
+    "pageTitle": "Kronik MHTC",
+    "pageDescription": "Dapatkan berita, artikel, dan maklumat terkini dari Majlis Pelancongan Kesihatan Malaysia.",
+    "categories": {
+        "title": "Kategori",
+        "items": {
+            "healthcareInnovations": "Inovasi Penjagaan Kesihatan",
+            "patientStories": "Kisah Pesakit",
+            "industryUpdates": "Kemas Kini Industri",
+            "events": "Acara",
+            "travelTips": "Petua Perjalanan"
+        }
+    },
+    "newsletter": {
+        "title": "Langgan Surat Berita Kami",
+        "description": "Sentiasa dikemas kini dengan berita dan maklumat terkini dari Majlis Pelancongan Kesihatan Malaysia.",
+        "emailPlaceholder": "Masukkan e-mel anda",
+        "subscribeButton": "Langgan"
+    },
+    "articles": {
+        "readMore": "Baca Lagi"
+    }
+}

--- a/mhtc-web/locales/zh/mhtc-chronicles.json
+++ b/mhtc-web/locales/zh/mhtc-chronicles.json
@@ -1,0 +1,23 @@
+{
+    "pageTitle": "MHTC 资讯专栏",
+    "pageDescription": "获取马来西亚医疗旅游理事会的最新新闻、文章和见解。",
+    "categories": {
+        "title": "分类",
+        "items": {
+            "healthcareInnovations": "医疗创新",
+            "patientStories": "患者故事",
+            "industryUpdates": "行业动态",
+            "events": "活动",
+            "travelTips": "旅行贴士"
+        }
+    },
+    "newsletter": {
+        "title": "订阅我们的电子报",
+        "description": "获取马来西亚医疗旅游理事会的最新新闻和见解。",
+        "emailPlaceholder": "输入您的电子邮箱",
+        "subscribeButton": "订阅"
+    },
+    "articles": {
+        "readMore": "阅读更多"
+    }
+}

--- a/mhtc-web/types/i18n.ts
+++ b/mhtc-web/types/i18n.ts
@@ -17,6 +17,7 @@ export type Namespace =
   | 'corporate-profile'
   | 'member-hospital'
   | 'healthcare-travel-guide'
+  | 'mhtc-chronicles'
   | 'navbar'
   | 'footer';
 

--- a/mhtc-web/types/translations.ts
+++ b/mhtc-web/types/translations.ts
@@ -501,3 +501,30 @@ export interface HealthcareTravelGuideTranslations {
     exploreStage: string;
   };
 }
+
+/**
+ * MHTC Chronicles page translations
+ */
+export interface MHTCChroniclesTranslations {
+  pageTitle: string;
+  pageDescription: string;
+  categories: {
+    title: string;
+    items: {
+      healthcareInnovations: string;
+      patientStories: string;
+      industryUpdates: string;
+      events: string;
+      travelTips: string;
+    };
+  };
+  newsletter: {
+    title: string;
+    description: string;
+    emailPlaceholder: string;
+    subscribeButton: string;
+  };
+  articles: {
+    readMore: string;
+  };
+}


### PR DESCRIPTION
- Create localization files for MHTC Chronicles page in multiple languages (English, Arabic, Indonesian, Malay, Chinese)
- Refactor page to use server-side translations and RTL support
- Update page metadata generation with dynamic translations
- Add new translation type for MHTC Chronicles
- Update i18n namespace type to include mhtc-chronicles

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Pages now display dynamic metadata and localized content based on the user's language selection.
  - Expanded localization support with new language resources for Arabic, English, Indonesian, Malaysian, and Chinese, ensuring a tailored experience.

- **Style**
  - Improved accessibility through enhanced attributes and focus management for a more user-friendly interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->