### PR TITLE
Remove external link attribute from MYMT 2026 navigation item in Head…

### DIFF
--- a/mhtc-web/components/home4/header.tsx
+++ b/mhtc-web/components/home4/header.tsx
@@ -24,7 +24,6 @@ const mainNavItems: NavItem[] = [
   {
     title: "MYMT 2026",
     href: "/mymt2026",
-    external: true,
   },
 ]
 


### PR DESCRIPTION
…er component

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the "MYMT 2026" navigation link to open within the site instead of a new browser tab.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->